### PR TITLE
add RDSN_TARGET_CONFIG env var so that deployment can change the tareget config

### DIFF
--- a/src/replica_server/replication_lib/replication_app_base.h
+++ b/src/replica_server/replication_lib/replication_app_base.h
@@ -201,6 +201,7 @@ private:
         );
 
     void install_perf_counters();
+    void uninstall_perf_counters();
 
 private:
     void* _app_context;


### PR DESCRIPTION
- add RDSN_TARGET_CONFIG env var so that deployment can change the tareget config
- fix a bug about performance counter usage in replicated app base which may lead to incorrect perf counters.